### PR TITLE
mumble-ping docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@
 # docker build files (so just changing them does not invalidate *all* caches)
 .dockerignore
 Dockerfile
+Dockerfile_ping

--- a/Dockerfile_ping
+++ b/Dockerfile_ping
@@ -1,8 +1,46 @@
 # syntax=docker/dockerfile:1.1.7-experimental
-######################
-# Base builder image #
-######################
-FROM golang:1.19.1-bullseye AS build
+########################
+# Alpine builder image #
+########################
+FROM golang:1.19.1-alpine3.16 AS build
+
+# Checkout
+RUN apk add --no-cache \
+        bash \
+        git openssh-client \
+    && mkdir -p /build \
+    && cd /build \
+    && git clone https://github.com/layeh/gumble.git \
+    && cd gumble \
+    && true
+
+# This arg is any valid git reference
+# pragma: allowlist nextline secret
+ARG GUMBLE_VERSION="146f9205029b73783dbd79043c4fc5247d8c425d"
+# Build
+RUN cd /build/gumble \
+    && git checkout $GUMBLE_VERSION \
+    && go build -v -o /build/mumble-ping -buildmode=exe cmd/mumble-ping/main.go \
+    && /build/mumble-ping --help \
+    && true
+
+#####################
+# Alpine ping image #
+#####################
+FROM alpine:3.16 as ping
+COPY --from=build /build/mumble-ping /bin/mumble-ping
+COPY ./docker/entrypoint-ping.sh /entrypoint.sh
+RUN apk add --no-cache \
+        bash \
+        coreutils \
+    && true
+SHELL ["/bin/bash", "-lc"]
+ENTRYPOINT ["/entrypoint.sh"]
+
+########################
+# Debian builder image #
+########################
+FROM golang:1.19.1-bullseye AS debianbuild
 ENV \
   # locale
   LC_ALL=C.UTF-8 \
@@ -34,11 +72,11 @@ RUN cd /build/gumble \
     && /build/mumble-ping --help \
     && true
 
-##########################
-# The minimal ping image #
-##########################
-FROM debian:bullseye-slim as ping
-COPY --from=build /build/mumble-ping /bin/mumble-ping
+#####################
+# Debian ping image #
+#####################
+FROM debian:bullseye-slim as debianping
+COPY --from=debianbuild /build/mumble-ping /bin/mumble-ping
 COPY ./docker/entrypoint-ping.sh /entrypoint.sh
 SHELL ["/bin/bash", "-lc"]
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile_ping
+++ b/Dockerfile_ping
@@ -1,0 +1,44 @@
+# syntax=docker/dockerfile:1.1.7-experimental
+######################
+# Base builder image #
+######################
+FROM golang:1.19.1-bullseye AS build
+ENV \
+  # locale
+  LC_ALL=C.UTF-8 \
+  # python:
+  PYTHONFAULTHANDLER=1 \
+  PYTHONUNBUFFERED=1 \
+  PYTHONHASHSEED=random \
+  # pip:
+  PIP_NO_CACHE_DIR=off \
+  PIP_DISABLE_PIP_VERSION_CHECK=on \
+  PIP_DEFAULT_TIMEOUT=100 \
+  # debconf
+  DEBIAN_FRONTEND=noninteractive
+
+# Checkout
+RUN mkdir -p /build \
+    && cd /build \
+    && git clone https://github.com/layeh/gumble.git \
+    && cd gumble \
+    && true
+
+# This arg is any valid git reference
+# pragma: allowlist nextline secret
+ARG GUMBLE_VERSION="146f9205029b73783dbd79043c4fc5247d8c425d"
+# Build
+RUN cd /build/gumble \
+    && git checkout $GUMBLE_VERSION \
+    && go build -v -o /build/mumble-ping -buildmode=pie cmd/mumble-ping/main.go \
+    && /build/mumble-ping --help \
+    && true
+
+##########################
+# The minimal ping image #
+##########################
+FROM debian:bullseye-slim as ping
+COPY --from=build /build/mumble-ping /bin/mumble-ping
+COPY ./docker/entrypoint-ping.sh /entrypoint.sh
+SHELL ["/bin/bash", "-lc"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/README.rst
+++ b/README.rst
@@ -25,3 +25,17 @@ If you just want murmurd to autogenerate its own self-signed certificate pass "-
 Coming back later::
 
   docker start mumbleserver
+
+
+Ping
+^^^^
+
+We also have a image for pinging a server
+
+build::
+
+    docker build --progress plain --ssh default --target ping  --tag mumbleping:latest  -f Dockerfile_ping .
+
+Run::
+
+    docker run --rm -it -e SERVER_DOMAIN=omething.example.com mumbleping:latest

--- a/docker/entrypoint-ping.sh
+++ b/docker/entrypoint-ping.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env -S /bin/bash -l
+set -e
+if [ "$#" -eq 0 ]; then
+  # ping the server in env
+  /bin/mumble-ping -json $SERVER_DOMAIN
+else
+  # run the given command
+  exec "$@"
+fi


### PR DESCRIPTION
Dockerfile_ping has both alpine and debian based targets but alpine is *much* smaller so it's the default and the one that is pushed to docker hub.